### PR TITLE
Fix skip_prefix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,6 @@ pub(crate) fn skip_prefix<'a>(input: &'a [u8], prefix: &[u8]) -> Option<&'a [u8]
     if input.starts_with(prefix) {
         Some(&input[prefix.len()..])
     } else {
-        None
+        Some(&input)
     }
 }


### PR DESCRIPTION
Hi! Thanks for this module, I'm using it in ssb-neon-keys and via ssb-keyfile(-rs). I noticed an error propagating when the SSB id being deserialized looks like `"QlcT...a92=.ed25519"`, that is, **without** the `@` in the beginning. This is the case in the so called "presigil legacy format" which ssb-keys (JS) currently tests for.

I noticed that this function `skip_prefix` is documented as "**If** the slice begins with the given prefix, return everything after" which doesn't quite specify what to do in the "else" case. Currently it's returning `None`, which is converted to an error.

In the "else" case, I thought about returning the input string itself, and this would end up supporting "presigil legacy format". This PR is a draft though, because this function `skip_prefix` should probably return just `[u8]` instead of `Option<[u8]>` since we're not using the `None` case. I can make a better PR later, this is just to open the discussion whether you think this is the right way to go.