### PR TITLE
Update dependencies, satisfy clippy and fix typos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssb-multiformats"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["AljoschaMeyer <mail@aljoscha-meyer.de>"]
 edition = "2018"
 license = "AGPL-3.0"
@@ -11,9 +11,9 @@ readme = "README.md"
 keywords = ["ssb", "scuttlebutt"]
 
 [dependencies]
-base64 = "0.11.0"
-serde = "1.0.104"
-ssb-crypto = {version = "0.2.1", default_features = false}
+base64 = "0.13.0"
+serde = "1.0.126"
+ssb-crypto = {version = "0.2.2", default_features = false}
 
 [dev-dependencies]
 matches = "0.1.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub(crate) fn split_at_byte(input: &[u8], byte: u8) -> Option<(&[u8], &[u8])> {
         }
     }
 
-    return None;
+    None
 }
 
 // If the slice begins with the given prefix, return everything after that prefix.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! Implementations of the [ssb multiformats](https://spec.scuttlebutt.nz/datatypes.html).
+//! Implementations of the [ssb multiformats](https://spec.scuttlebutt.nz/feed/datatypes.html).
 // #![warn(missing_docs)]
 
 extern crate base64;
@@ -17,7 +17,7 @@ pub mod multikey;
 // A bunch of helper functions used throughout the crate for parsing legacy encodings.
 ////////////////////////////////////////////////////////////////////////////////
 
-// Split the input slice at the first occurence o the given byte, the byte itself is not
+// Split the input slice at the first occurence of the given byte, the byte itself is not
 // part of any of the returned slices. Return `None` if the byte is not found in the input.
 pub(crate) fn split_at_byte(input: &[u8], byte: u8) -> Option<(&[u8], &[u8])> {
     for i in 0..input.len() {

--- a/src/multifeed.rs
+++ b/src/multifeed.rs
@@ -18,16 +18,16 @@ impl Multifeed {
     /// [legacy encoding](https://spec.scuttlebutt.nz/datatypes.html#multifeed-legacy-encoding)
     /// into a `Multifeed`, also returning the remaining input on success.
     pub fn from_legacy(s: &[u8]) -> Result<(Multifeed, &[u8]), DecodeLegacyError> {
-        if s.len() == 0 {
+        if s.is_empty() {
             return Err(DecodeLegacyError::UnknownKind);
         }
 
         match s[0] {
             0x40 => {
                 let (mk, tail) = Multikey::from_legacy(s)?;
-                return Ok((Multifeed::from_multikey(mk), tail));
+                Ok((Multifeed::from_multikey(mk), tail))
             }
-            _ => return Err(DecodeLegacyError::UnknownKind),
+            _ => Err(DecodeLegacyError::UnknownKind),
         }
     }
 

--- a/src/multifeed.rs
+++ b/src/multifeed.rs
@@ -15,7 +15,7 @@ impl Multifeed {
     }
 
     /// Parses a
-    /// [legacy encoding](https://spec.scuttlebutt.nz/datatypes.html#multifeed-legacy-encoding)
+    /// [legacy encoding](https://spec.scuttlebutt.nz/feed/datatypes.html#multifeed-legacy-encoding)
     /// into a `Multifeed`, also returning the remaining input on success.
     pub fn from_legacy(s: &[u8]) -> Result<(Multifeed, &[u8]), DecodeLegacyError> {
         if s.is_empty() {
@@ -32,7 +32,7 @@ impl Multifeed {
     }
 
     /// Serialize a `Multifeed` into a writer, using the
-    /// [legacy encoding](https://spec.scuttlebutt.nz/datatypes.html#multifeed-legacy-encoding).
+    /// [legacy encoding](https://spec.scuttlebutt.nz/feed/datatypes.html#multifeed-legacy-encoding).
     pub fn to_legacy<W: Write>(&self, w: &mut W) -> Result<(), io::Error> {
         match self {
             Multifeed::Multikey(ref mk) => mk.to_legacy(w),
@@ -40,7 +40,7 @@ impl Multifeed {
     }
 
     /// Serialize a `Multifeed` into an owned byte vector, using the
-    /// [legacy encoding](https://spec.scuttlebutt.nz/datatypes.html#multifeed-legacy-encoding).
+    /// [legacy encoding](https://spec.scuttlebutt.nz/feed/datatypes.html#multifeed-legacy-encoding).
     pub fn to_legacy_vec(&self) -> Vec<u8> {
         match self {
             Multifeed::Multikey(ref mk) => mk.to_legacy_vec(),
@@ -48,7 +48,7 @@ impl Multifeed {
     }
 
     /// Serialize a `Multifeed` into an owned string, using the
-    /// [legacy encoding](https://spec.scuttlebutt.nz/datatypes.html#multifeed-legacy-encoding).
+    /// [legacy encoding](https://spec.scuttlebutt.nz/feed/datatypes.html#multifeed-legacy-encoding).
     pub fn to_legacy_string(&self) -> String {
         unsafe { String::from_utf8_unchecked(self.to_legacy_vec()) }
     }

--- a/src/multikey.rs
+++ b/src/multikey.rs
@@ -1,4 +1,4 @@
-//! Implementation of [ssb multikeys](https://spec.scuttlebutt.nz/datatypes.html#multikey).
+//! Implementation of [ssb multikeys](https://spec.scuttlebutt.nz/feed/datatypes.html#multikey).
 use std::cmp::{Eq, Ord, PartialEq, PartialOrd};
 use std::fmt;
 use std::io::{self, Cursor, Write};
@@ -35,7 +35,7 @@ impl Multikey {
     }
 
     /// Parses a
-    /// [legacy encoding](https://spec.scuttlebutt.nz/datatypes.html#multikey-legacy-encoding)
+    /// [legacy encoding](https://spec.scuttlebutt.nz/feed/datatypes.html#multikey-legacy-encoding)
     /// into a `Multikey`, also returning the remaining input on success.
     pub fn from_legacy(mut s: &[u8]) -> Result<(Multikey, &[u8]), DecodeLegacyError> {
         s = skip_prefix(s, b"@").ok_or(DecodeLegacyError::Sigil)?;
@@ -56,7 +56,7 @@ impl Multikey {
             return Err(DecodeLegacyError::Ed25519WrongSize);
         }
 
-        let mut dec_data = [0u8; 32];
+        let mut dec_data = [0_u8; 32];
 
         base64::decode_config_slice(data, base64::STANDARD, &mut dec_data)
             .map_err(|_| DecodeLegacyError::InvalidBase64)
@@ -64,7 +64,7 @@ impl Multikey {
     }
 
     /// Serialize a `Multikey` into a writer, using the
-    /// [legacy encoding](https://spec.scuttlebutt.nz/datatypes.html#multikey-legacy-encoding).
+    /// [legacy encoding](https://spec.scuttlebutt.nz/feed/datatypes.html#multikey-legacy-encoding).
     pub fn to_legacy<W: Write>(&self, w: &mut W) -> Result<(), io::Error> {
         match self {
             Multikey::Ed25519(ref pk) => {
@@ -80,7 +80,7 @@ impl Multikey {
     }
 
     /// Serialize a `Multikey` into an owned byte vector, using the
-    /// [legacy encoding](https://spec.scuttlebutt.nz/datatypes.html#multikey-legacy-encoding).
+    /// [legacy encoding](https://spec.scuttlebutt.nz/feed/datatypes.html#multikey-legacy-encoding).
     pub fn to_legacy_vec(&self) -> Vec<u8> {
         let mut data = vec![];
         self.to_legacy(&mut data).unwrap();
@@ -88,7 +88,7 @@ impl Multikey {
     }
 
     /// Serialize a `Multikey` into an owned string, using the
-    /// [legacy encoding](https://spec.scuttlebutt.nz/datatypes.html#multikey-legacy-encoding).
+    /// [legacy encoding](https://spec.scuttlebutt.nz/feed/datatypes.html#multikey-legacy-encoding).
     pub fn to_legacy_string(&self) -> String {
         String::from_utf8(self.to_legacy_vec()).unwrap()
     }
@@ -129,7 +129,7 @@ pub enum DecodeLegacyError {
     Sigil,
     /// Input did not contain a `"."` to separate the data from the suffix.
     NoDot,
-    /// Invalid utf8 string
+    /// Invalid utf8 string.
     InvalidUTF8,
     /// The base64 portion of the key was invalid.
     InvalidBase64,
@@ -154,13 +154,13 @@ impl fmt::Display for DecodeLegacyError {
 
 impl std::error::Error for DecodeLegacyError {}
 
-/// The secret counterpart to Multikey
+/// The secret counterpart to Multikey.
 #[derive(Debug, Clone)]
 pub struct Multisecret(Keypair);
 
 impl Multisecret {
     /// Parses a
-    /// [legacy encoding](https://spec.scuttlebutt.nz/datatypes.html#multikey-legacy-encoding)
+    /// [legacy encoding](https://spec.scuttlebutt.nz/feed/datatypes.html#multikey-legacy-encoding)
     /// into a `Multisecret`, also returning the remaining input on success.
     pub fn from_legacy(s: &[u8]) -> Result<(Multisecret, &[u8]), DecodeLegacyError> {
         let (data, suffix) = split_at_byte(s, 0x2E).ok_or(DecodeLegacyError::NoDot)?;
@@ -175,7 +175,7 @@ impl Multisecret {
     }
 
     /// Serialize a `Multisecret` into a writer, using the
-    /// [legacy encoding](https://spec.scuttlebutt.nz/datatypes.html#multikey-legacy-encoding).
+    /// [legacy encoding](https://spec.scuttlebutt.nz/feed/datatypes.html#multikey-legacy-encoding).
     pub fn to_legacy<W: Write>(&self, w: &mut W) -> Result<(), io::Error> {
         let data = self.0.as_base64();
         w.write_all(data.as_bytes())?;
@@ -189,7 +189,7 @@ impl Serialize for Multisecret {
     where
         S: Serializer,
     {
-        let mut s = [0u8; SSB_ED25519_SECRET_ENCODED_LEN];
+        let mut s = [0_u8; SSB_ED25519_SECRET_ENCODED_LEN];
         self.to_legacy(&mut Cursor::new(&mut s[..])).unwrap();
         serializer.serialize_str(std::str::from_utf8(&s).unwrap())
     }
@@ -236,7 +236,7 @@ impl PartialEq for _Multisig {
 impl Eq for _Multisig {}
 
 impl Multikey {
-    /// Deserialize a legacy signature corrsponding to this key type.
+    /// Deserialize a legacy signature corresponding to this key type.
     pub fn sig_from_legacy<'a>(
         &self,
         s: &'a [u8],
@@ -258,7 +258,7 @@ impl Multikey {
                     return Err(DecodeSignatureError::Ed25519WrongSize);
                 }
 
-                let mut dec_data = [0u8; 64];
+                let mut dec_data = [0_u8; 64];
 
                 base64::decode_config_slice(data, base64::STANDARD, &mut dec_data[..])
                     .map_err(DecodeSignatureError::InvalidBase64)
@@ -275,7 +275,7 @@ impl Multisig {
     }
 
     /// Serialize a signature into a writer, in the appropriate
-    /// form for a [legacy message](https://spec.scuttlebutt.nz/messages.html#legacy-json-encoding).
+    /// form for a [legacy message](https://spec.scuttlebutt.nz/feed/messages.html#legacy-json-encoding).
     pub fn to_legacy<W: Write>(&self, w: &mut W) -> Result<(), io::Error> {
         match self.0 {
             _Multisig::Ed25519(ref sig) => {
@@ -288,7 +288,7 @@ impl Multisig {
 
     /// Serialize a signature into an owned byte vector,
     /// in the appropriate form for a
-    /// [legacy message](https://spec.scuttlebutt.nz/messages.html#legacy-json-encoding).
+    /// [legacy message](https://spec.scuttlebutt.nz/feed/messages.html#legacy-json-encoding).
     pub fn to_legacy_vec(&self) -> Vec<u8> {
         let mut data = vec![];
         self.to_legacy(&mut data).unwrap();
@@ -297,7 +297,7 @@ impl Multisig {
 
     /// Serialize a signature into an owned string,
     /// in the appropriate form for a
-    /// [legacy message](https://spec.scuttlebutt.nz/messages.html#legacy-json-encoding).
+    /// [legacy message](https://spec.scuttlebutt.nz/feed/messages.html#legacy-json-encoding).
     pub fn to_legacy_string(&self) -> String {
         String::from_utf8(self.to_legacy_vec()).unwrap()
     }


### PR DESCRIPTION
A few basic maintenance updates:

 - Bump crate version to `0.4.1`
 - Update dependencies (bring `ssb-crypto` up to `0.2.2`)
 - Fix broken doc URLs and typos
 - Implement changes suggested by clippy (increase readability and idiomaticity)
   - [`redundant_static_lifetimes`](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_static_lifetimes)
   - [`unnecessary_lazy_evaluations`](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations)
   - [`redundant_closure`](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure)
   - [`needless_return`](https://rust-lang.github.io/rust-clippy/master/index.html#needless_return)
   - [`needless_borrow`](https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow)
   - plus a few pedantic ones like removing `*` imports from `super` and changing `0u8` -> `0_u8`